### PR TITLE
Preparing for Ansible 2.12 deprecation warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,7 +77,7 @@
   timezone:
     name: "{{ ntp_timezone }}"
   when:
-    - ntp_timezone_supported
+    - ntp_timezone_supported | bool
     - ansible_virtualization_type != "docker"
   notify:
     - restart cron


### PR DESCRIPTION
---
Prepare for Ansible 2.12 compatibility
Ansible 2.8.1 throws DEPRECATION WARNINGS for using bare variable
conditionals. This patch fixes the warning.---

**Describe the change**
This is the warning message that's presented by using conditional bare vars.

> [DEPRECATION WARNING]: evaluating ntp_timezone_supported as a bare
> variable, this behavior will go away and you might need to add
> |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS
> configuration toggle.. This feature will be removed in version
> 2.12. Deprecation warnings can be disabled by setting
> deprecation_warnings=False in ansible.cfg.


**Testing**
Only tested locally in my environment. Not familiar with testing Ansible roles.
