### PR TITLE
Allow timezone update in Debian

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -35,6 +35,7 @@ ntp_timezone_packages: "{{ _ntp_timezone_packages[ansible_distribution] | defaul
 
 _ntp_timezone_supported:
   default: no
+  Debian: yes
   CentOS-6: yes
 
 ntp_timezone_supported: "{{ _ntp_timezone_supported[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_ntp_timezone_supported[ansible_distribution] | default(_ntp_timezone_supported['default'])) }}"


### PR DESCRIPTION
---
name: Allow timezone updates in Debian
about: Adds Debian to the list of OSs that support timezone update

---
**Describe the change**
Adds Debian to the list of OSs that support timezone update

**Testing**
Only tested locally in my environment. Not familiar with testing Ansible roles.