### PR TITLE
Support timezone configuration on all CentOS

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -36,6 +36,6 @@ ntp_timezone_packages: "{{ _ntp_timezone_packages[ansible_distribution] | defaul
 _ntp_timezone_supported:
   default: no
   Debian: yes
-  CentOS-6: yes
+  CentOS: yes
 
 ntp_timezone_supported: "{{ _ntp_timezone_supported[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_ntp_timezone_supported[ansible_distribution] | default(_ntp_timezone_supported['default'])) }}"


### PR DESCRIPTION
---
name: Enable Timezone configuration for CentOS-6 and -7
about: Timezone configuration is only enabled for Debian and CentOS6. The goal of this change is to enable Timezone configuration for CentOS-7 as well.

---

**Describe the change**
Chech only for distribution, instead of distribution-major_version.

I might not be aware of reasons that lead to the creation of this condition but I would argue is not necessary and should be completely removed to allow different distributions to support timezone configuration.

Ansible's timezone task documentation states that it does not support Windows, AIX and HPUX.
https://docs.ansible.com/ansible/latest/modules/timezone_module.html

Maybe a better approach would be to skip configuration only for those OSs.
