### PR TITLE
configure timezone in ubuntu

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -41,6 +41,7 @@ ntp_timezone_packages: "{{ _ntp_timezone_packages[ansible_os_family] | default(_
 _ntp_timezone_supported:
   default: no
   Debian: yes
+  Ubuntu: yes
   CentOS: yes
 
 ntp_timezone_supported: "{{ _ntp_timezone_supported[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_ntp_timezone_supported[ansible_distribution] | default(_ntp_timezone_supported['default'])) }}"


### PR DESCRIPTION
---
name: Pull request
about: configure timezone in ubuntu

---

While testing this role in a ubuntu 20.04 machine I noticed that task [configure timezone](https://github.com/robertdebock/ansible-role-ntp/blob/master/tasks/main.yml#L26-L32) was not being applied because `ntp_timezone_supported` was `false`.

`ansible_distribution` var from facts is `Ubuntu` and the timezone config is applied with this change